### PR TITLE
Quick addition of hinting system in single answer edit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -257,8 +257,17 @@ $(document).on('turbolinks:load', function() {
 
   insertTextArea = function(inputObj) {
       id = $(inputObj).attr('id')
+      onchange = $(inputObj).attr('onchange')
       identifier = id[id.length-1]
-      $(inputObj).after('<textarea onchange="changeMe(\''+ id  + '\',\'answer-hint-'+ identifier +'\')" oninput="this.onchange()" name="answers[][hint]" id=' + id + '></textarea>')
+
+      if (window.location.pathname.match(/new/)) {
+        $(inputObj).after('<textarea onchange="changeMe(\''+ id  + '\',\'answer-hint-'+ identifier +'\')" oninput="this.onchange()" name="answers[][hint]" id=' + id + '></textarea>')
+      } else {
+        current_hint = document.getElementById('answer-hint-presenter').innerHTML
+
+        $(inputObj).after('<textarea onchange="changeMe(\'answer_hint\',\'answer-hint-presenter\')" oninput="this.onchange()" name="answer[hint]" id=' + id + '>' + current_hint + '</textarea>')
+      }
+
       $(inputObj).attr('id', '')
       $(inputObj).attr('name', '')
       notSet = false

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -5,7 +5,7 @@
     <%= f.label :solution %>
     <%= f.text_area :solution %>
     <%= f.label :hint %>
-    <%= f.text_area :hint, onchange: "changeMe('answer_hint','answer-hint-presenter')", oninput: "this.onchange()" %>
+    <%= f.select :hint, AnswersHelper::ANSWER_HINTS + ['Other'], {}, onchange: "changeMe('answer_hint','answer-hint-presenter')", oninput: "this.onchange()", id: "answer_hint" %>
     <%= f.label :answer_type %>
     <%= f.select :answer_type, ["inequality", "coordinates", "equation", "words", "normal"], selected: @answer.answer_type %>
     <%= f.label :order %>
@@ -18,5 +18,5 @@
 <div class="answer-answers null-margin answer-right">
   <label for="dummy" id="answer-label-presenter" class="answer-label-style" > <%= @answer.label %> </label>
   <input type="text"  > </input>
-  <span class="answer-hint" id="answer-hint-presenter"> <%= @answer.hint %> </span>
+  <span class="answer-hint" id="answer-hint-presenter"> <%= print_hint(@answer.hint) %> </span>
 </div>

--- a/app/views/shared/_lesson_video.html.erb
+++ b/app/views/shared/_lesson_video.html.erb
@@ -1,5 +1,5 @@
 <a href="#" class="toggle-hide-video"><i class='fa fa-arrow-down' aria-hidden='true'></i> Hide Video</a>
 <div class='video-screen' style="display:none;">
-  <iframe style="margin-left:40px;" width="940" height="580" src="https://www.youtube.com/embed/<%= lesson.video %>" frameborder="0" allowfullscreen></iframe>
+  <!-- <iframe style="margin-left:40px;" width="940" height="580" src="https://www.youtube.com/embed/<%= lesson.video %>" frameborder="0" allowfullscreen></iframe> -->
 </div>
 <a href="#" class="toggle-video">Show Video</a>

--- a/spec/non_js_tests/features/answers_feature_spec.rb
+++ b/spec/non_js_tests/features/answers_feature_spec.rb
@@ -116,16 +116,17 @@ feature 'answers' do
   end
 
   context 'updating answers' do
-    scenario 'an admin can update answers' do
+    scenario 'an admin can update answers', js: true do
       sign_in admin
-      visit "/"
-      click_link "Add Question"
+      visit "/questions/new"
       click_link("edit-question-#{question_1.id}-answer-#{answer_1.id}")
       fill_in 'Label', with: 'x111'
       fill_in 'Solution', with: '222'
-      fill_in 'Hint', with: 'No hints'
+      select 'Other', from: 'Hint'
+      fill_in 'answer_hint', with: 'No hint'
       click_button 'Update Answer'
       expect(page).to have_content 'x111'
+      expect(page).to have_content 'Hint No hint'
       expect(current_path).to eq "/questions/new"
     end
 


### PR DESCRIPTION
- Added new global hint system to `answers/edit.html.erb` as it did not have it.
- Updated JS to automatically populate the hint text-area with the current hint in only for `edit` page